### PR TITLE
[fix] Fix to read .yml file extension for docker-compose config file

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,10 +3,20 @@ use std::{fs, path::Path};
 use crate::deserializer::{deserialize_yaml, Compose};
 
 pub fn deserialize_compose_file(path: Option<String>) -> Result<Compose, serde_yaml::Error> {
-  let compose_file = Path::new(".").join("docker-compose.yaml");
-  let Ok(yaml) = fs::read_to_string(path.unwrap_or(compose_file.to_str().unwrap().to_string())) else {
-    panic!("No docker-compose.yaml file found");
+  if let Some(path) = path {
+    let yaml = fs::read_to_string(path).expect("Failed to read the provided compose file");
+    return deserialize_yaml(&yaml);
   };
 
-  deserialize_yaml(&yaml)
+  let default_candidates = ["docker-compose.yaml", "docker-compose.yml"];
+
+  for candidate in default_candidates.iter() {
+    let path = Path::new(".").join(candidate);
+    if path.exists() {
+      let yaml = fs::read_to_string(path).expect("Failed to read compose file");
+      return deserialize_yaml(&yaml);
+    }
+  }
+
+  panic!("No docker-compose.yaml or docker-compose.yml file found");
 }


### PR DESCRIPTION
Fix deserialize function to allow reading from `docker-compose.yml` file.

Related #4

