### PR TITLE
fix: allow files with empty environment variables, ports, and volumes

### DIFF
--- a/src/deserializer.rs
+++ b/src/deserializer.rs
@@ -8,10 +8,11 @@ use std::fmt;
 pub struct Service {
   pub name: Option<String>,
   pub image: String,
+  #[serde(default)]
   pub ports: Vec<String>,
-  #[serde(deserialize_with = "deserialize_environment_variables")]
+  #[serde(default, deserialize_with = "deserialize_environment_variables")]
   pub environment: HashMap<String, String>,
-  #[serde(deserialize_with = "deserialize_array_key_value")]
+  #[serde(default, deserialize_with = "deserialize_array_key_value")]
   pub volumes: HashMap<String, String>,
   #[serde(default, deserialize_with = "deserialize_command")]
   pub command: Option<Vec<String>>,


### PR DESCRIPTION
Fix issue https://github.com/noghartt/container-compose/issues/9.

Allows `docker-compose.yaml` files without ports, environment variables, and volumes.

Added default values for serde structs because it is straightforward and it works ([ref here](https://serde.rs/attr-default.html)).
But it can also be fixed by changing [deserialize_environment_variables](https://github.com/noghartt/container-compose/blob/main/src/deserializer.rs#L33) and [deserialize_array_key_value](https://github.com/noghartt/container-compose/blob/main/src/deserializer.rs#L77).

Thanks! 🐳 