### PR TITLE
feat: support `cpu_count` and `mem_limit`

### DIFF
--- a/examples/docker-compose.yaml
+++ b/examples/docker-compose.yaml
@@ -7,3 +7,5 @@ services:
       - 5432:5432
     environment:
       - POSTGRES_PASSWORD=postgres
+    cpu_count: 1
+    mem_limit: 2gb

--- a/src/deserializer.rs
+++ b/src/deserializer.rs
@@ -16,6 +16,10 @@ pub struct Service {
     pub volumes: HashMap<String, String>,
     #[serde(default, deserialize_with = "deserialize_command")]
     pub command: Option<Vec<String>>,
+    #[serde(default, alias = "cpu")]
+    pub cpu_count: Option<u32>,
+    #[serde(default)]
+    pub mem_limit: Option<String>,
 }
 
 #[allow(dead_code, unused_variables)]

--- a/src/deserializer.rs
+++ b/src/deserializer.rs
@@ -16,7 +16,7 @@ pub struct Service {
     pub volumes: HashMap<String, String>,
     #[serde(default, deserialize_with = "deserialize_command")]
     pub command: Option<Vec<String>>,
-    #[serde(default, alias = "cpu")]
+    #[serde(default)]
     pub cpu_count: Option<u32>,
     #[serde(default)]
     pub mem_limit: Option<String>,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -55,6 +55,8 @@ struct ServiceContainer {
     image: String,
     volumes: HashMap<String, String>,
     command: Option<Vec<String>>,
+    cpu_count: Option<u32>,
+    mem_limit: Option<String>,
 }
 
 impl ServiceContainer {
@@ -66,6 +68,8 @@ impl ServiceContainer {
             image: service.image.clone(),
             volumes: service.volumes.clone(),
             command: service.command.clone(),
+            cpu_count: service.cpu_count,
+            mem_limit: service.mem_limit.clone(),
         }
     }
 
@@ -94,6 +98,14 @@ impl ServiceContainer {
                 "type=bind,source={},target={}",
                 abs_source_str, value
             ));
+        }
+
+        // Add CPU and memory limits if specified
+        if let Some(cpu_count) = self.cpu_count {
+            output.arg("--cpus").arg(cpu_count.to_string());
+        }
+        if let Some(mem_limit) = &self.mem_limit {
+            output.arg("--memory").arg(mem_limit);
         }
 
         let output = output.arg("-d").arg(self.image.clone());


### PR DESCRIPTION
Adds support for CPU and memory limits https://github.com/noghartt/container-compose/issues/14

Memory limit must be in [byte values](https://docs.docker.com/reference/compose-file/extension/#specifying-byte-values), as originally supported by docker-compose.

Updates the sample file with the newly supported arguments.