### PR TITLE
fix: allow empty version argument

### DIFF
--- a/src/deserializer.rs
+++ b/src/deserializer.rs
@@ -21,6 +21,7 @@ pub struct Service {
 #[allow(dead_code, unused_variables)]
 #[derive(Debug, Deserialize)]
 pub struct Compose {
+    #[serde(default)]
     pub version: String,
     pub services: HashMap<String, Service>,
 }


### PR DESCRIPTION
Adds default value for `version` argument, making yaml files without the version arg to be valid.

Fix the issue reported by @wbreiler on https://github.com/noghartt/container-compose/issues/9#issuecomment-2983969408